### PR TITLE
 STEP10 - Finalize 

### DIFF
--- a/src/main/java/kr/hhplus/be/server/config/WebConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/WebConfig.java
@@ -1,0 +1,43 @@
+package kr.hhplus.be.server.config;
+
+import jakarta.servlet.Filter;
+import kr.hhplus.be.server.config.filter.AdvanceLogFilter;
+import kr.hhplus.be.server.config.filter.LogFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Bean
+	public FilterRegistrationBean<Filter> encodingFilter() {
+		CharacterEncodingFilter filter = new CharacterEncodingFilter();
+		filter.setEncoding("UTF-8");
+		filter.setForceEncoding(true); // 요청, 응답 모두 UTF-8로 강제
+
+		FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
+		registrationBean.setFilter(filter);
+		registrationBean.setOrder(0); // 가장 먼저 실행되도록!
+		registrationBean.addUrlPatterns("/*");
+
+		return registrationBean;
+	}
+
+	@Bean
+	public FilterRegistrationBean<Filter> advanceLogFilter() {
+		CharacterEncodingFilter filter = new CharacterEncodingFilter();
+		filter.setEncoding("UTF-8");
+		filter.setForceEncoding(true);
+
+		FilterRegistrationBean<Filter> filterBean = new FilterRegistrationBean<>();
+		filterBean.setFilter(new AdvanceLogFilter());
+		filterBean.setOrder(1); // logFilter 다음에 실행됨
+		filterBean.addUrlPatterns("/*");
+		return filterBean;
+	}
+
+
+}

--- a/src/main/java/kr/hhplus/be/server/config/filter/AdvanceLogFilter.java
+++ b/src/main/java/kr/hhplus/be/server/config/filter/AdvanceLogFilter.java
@@ -1,0 +1,86 @@
+package kr.hhplus.be.server.config.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+@Slf4j
+public class AdvanceLogFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		HttpServletRequest req = (HttpServletRequest) request;
+		HttpServletResponse res = (HttpServletResponse) response;
+
+		ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(req);
+		ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(res);
+
+		String uuid = UUID.randomUUID().toString();
+		String requestURI = req.getRequestURI();
+		LocalDateTime requestTime = LocalDateTime.now();
+		long startTime = System.currentTimeMillis();
+
+		try {
+			chain.doFilter(wrappedRequest, wrappedResponse);
+		} finally {
+			long duration = System.currentTimeMillis() - startTime;
+			LocalDateTime responseTime = LocalDateTime.now();
+
+			logRequest(wrappedRequest, uuid, requestURI, requestTime);
+			logResponse(wrappedResponse, uuid, requestURI, responseTime, duration);
+			wrappedResponse.copyBodyToResponse();
+		}
+	}
+
+	private void logRequest(ContentCachingRequestWrapper request, String uuid, String uri, LocalDateTime time) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		sb.append("\n====================== REQUEST START ======================\n");
+		sb.append("UUID        : ").append(uuid).append("\n");
+		sb.append("Timestamp   : ").append(time).append("\n");
+		sb.append("URI         : ").append(request.getMethod()).append(" ").append(uri).append("\n");
+		sb.append("Headers     :\n");
+		Collections.list(request.getHeaderNames()).forEach(name -> {
+			sb.append("    ").append(name).append(": ").append(request.getHeader(name)).append("\n");
+		});
+		sb.append("Body        :\n");
+		sb.append(getBodyAsString(request.getContentAsByteArray(), request.getCharacterEncoding())).append("\n");
+		sb.append("======================= REQUEST END =======================\n");
+
+		log.info(sb.toString());
+	}
+
+	private void logResponse(ContentCachingResponseWrapper response, String uuid, String uri, LocalDateTime time, long duration) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		sb.append("\n====================== RESPONSE START =====================\n");
+		sb.append("UUID        : ").append(uuid).append("\n");
+		sb.append("Timestamp   : ").append(time).append("\n");
+		sb.append("URI         : ").append(uri).append("\n");
+		sb.append("Status      : ").append(response.getStatus()).append("\n");
+		sb.append("Duration    : ").append(duration).append(" ms\n");
+		sb.append("Headers     :\n");
+		response.getHeaderNames().forEach(name -> {
+			sb.append("    ").append(name).append(": ").append(response.getHeader(name)).append("\n");
+		});
+		sb.append("Body        :\n");
+		sb.append(getBodyAsString(response.getContentAsByteArray(), response.getCharacterEncoding())).append("\n");
+		sb.append("======================= RESPONSE END ======================\n");
+
+		log.info(sb.toString());
+	}
+
+	private String getBodyAsString(byte[] content, String encoding) throws UnsupportedEncodingException {
+		if (content.length == 0) return "[No Body]";
+		return new String(content, encoding);
+	}
+}


### PR DESCRIPTION
요청/응답 시 데이터를 로깅하는 필터를 구현하였습니다. 

## **리뷰 포인트(질문)**
- 요청 응답 데이터 로깅 시 필터/인터셉터 중 필터를 사용하는 게 좋을까요?
- HttpServletRequest.getInputStream() 는 한번 읽으면 사용할 수 없기때문에 로깅에 서 사용하게되면 스프링 컨트롤러에서 읽을수 없어 예외를 발생시키는 것으로 알고 있습니다. 
- 그래서 doFilter()로 스프링으로 요청이 들어간 후 `ContentCachingRequestWrapper`를 사용하여 로깅에 body 데이터를 바인딩 하였는데 
- 요청과 응답이 종료된 후에 로그가 출력됩니다. 
- 
- request가 로깅된 후 비즈니스 로직이 실행되고 response 응답을 로깅하고 싶은데 다른 방법을 사용해야 할까요? 